### PR TITLE
Add MUI based auth pages

### DIFF
--- a/insight/app/account/page.js
+++ b/insight/app/account/page.js
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+import { Avatar, Box, Button, Container, Typography } from '@mui/material';
+import Navbar from '../components/navbar';
+
+export default function AccountPage() {
+  const [user] = useState({ name: 'John Doe', email: 'john@example.com' });
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="sm" sx={{ mt: 8 }}>
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <Avatar sx={{ width: 80, height: 80, mb: 2 }}>{user.name.charAt(0)}</Avatar>
+          <Typography variant="h5">{user.name}</Typography>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            {user.email}
+          </Typography>
+          <Button variant="contained">Edit</Button>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/insight/app/components/navbar.js
+++ b/insight/app/components/navbar.js
@@ -18,6 +18,7 @@ export default function Navbar() {
             <Link href="/signup/consultant" className="hover:text-blue-200 font-medium transition">Become a Consultant</Link>
             <Link href="/about" className="hover:text-blue-200 font-medium transition">About</Link>
             <Link href="/contact" className="hover:text-blue-200 font-medium transition">Contact</Link>
+            <Link href="/login" className="hover:text-blue-200 font-medium transition">Login</Link>
           </div>
           {/* Mobile Menu Button */}
           <div className="md:hidden">

--- a/insight/app/layout.js
+++ b/insight/app/layout.js
@@ -1,5 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -16,13 +18,16 @@ export const metadata = {
   description: "Online Consultant tool",
 };
 
+const theme = createTheme();
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/insight/app/login/page.js
+++ b/insight/app/login/page.js
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Button, Container, Link, TextField, Typography } from '@mui/material';
+import NextLink from 'next/link';
+import Navbar from '../components/navbar';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="sm" sx={{ mt: 8 }}>
+        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Sign in
+          </Typography>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Email Address"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3 }}>
+            Sign In
+          </Button>
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            Don't have an account?{' '}
+            <Link component={NextLink} href="/register">
+              Sign up
+            </Link>
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/insight/app/register/page.js
+++ b/insight/app/register/page.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Button, Container, Link, TextField, Typography } from '@mui/material';
+import NextLink from 'next/link';
+import Navbar from '../components/navbar';
+
+export default function RegisterPage() {
+  const [values, setValues] = useState({ firstName: '', lastName: '', email: '', password: '' });
+
+  const handleChange = (field) => (e) => {
+    setValues({ ...values, [field]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="sm" sx={{ mt: 8 }}>
+        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Sign up
+          </Typography>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="First Name"
+            value={values.firstName}
+            onChange={handleChange('firstName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Last Name"
+            value={values.lastName}
+            onChange={handleChange('lastName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Email Address"
+            type="email"
+            value={values.email}
+            onChange={handleChange('email')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Password"
+            type="password"
+            value={values.password}
+            onChange={handleChange('password')}
+          />
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3 }}>
+            Register
+          </Button>
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            Already have an account?{' '}
+            <Link component={NextLink} href="/login">
+              Sign in
+            </Link>
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/insight/package.json
+++ b/insight/package.json
@@ -11,7 +11,11 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "next": "15.3.2",
+    "@mui/material": "^5.15.16",
+    "@mui/icons-material": "^5.15.16",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- integrate Material UI theme in the root layout
- link to login from the navbar
- add login and registration pages
- add a simple account page
- install Material UI packages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d1aefbe88321be37bbf7742e97e3