### PR TITLE
Implement navigation to account form

### DIFF
--- a/insight/app/account/page.js
+++ b/insight/app/account/page.js
@@ -1,23 +1,77 @@
 'use client';
 
 import { useState } from 'react';
-import { Avatar, Box, Button, Container, Typography } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { Box, Button, Container, TextField, Typography } from '@mui/material';
 import Navbar from '../components/navbar';
 
 export default function AccountPage() {
-  const [user] = useState({ name: 'John Doe', email: 'john@example.com' });
+  const router = useRouter();
+  const [values, setValues] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    certificate: null,
+  });
+
+  const handleChange = (field) => (e) => {
+    setValues({ ...values, [field]: e.target.value });
+  };
+
+  const handleFileChange = (e) => {
+    setValues({ ...values, certificate: e.target.files[0] });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    router.push('/');
+  };
 
   return (
     <>
       <Navbar />
       <Container maxWidth="sm" sx={{ mt: 8 }}>
-        <Box display="flex" flexDirection="column" alignItems="center">
-          <Avatar sx={{ width: 80, height: 80, mb: 2 }}>{user.name.charAt(0)}</Avatar>
-          <Typography variant="h5">{user.name}</Typography>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            {user.email}
+        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Account Details
           </Typography>
-          <Button variant="contained">Edit</Button>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="First Name"
+            value={values.firstName}
+            onChange={handleChange('firstName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Last Name"
+            value={values.lastName}
+            onChange={handleChange('lastName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Email Address"
+            type="email"
+            value={values.email}
+            onChange={handleChange('email')}
+          />
+          <Button variant="outlined" component="label" sx={{ mt: 2 }}>
+            Upload Certificate
+            <input hidden type="file" onChange={handleFileChange} />
+          </Button>
+          {values.certificate && (
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              {values.certificate.name}
+            </Typography>
+          )}
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3 }}>
+            Save
+          </Button>
         </Box>
       </Container>
     </>

--- a/insight/app/register/page.js
+++ b/insight/app/register/page.js
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Box, Button, Container, Link, TextField, Typography } from '@mui/material';
 import NextLink from 'next/link';
 import Navbar from '../components/navbar';
 
 export default function RegisterPage() {
   const [values, setValues] = useState({ firstName: '', lastName: '', email: '', password: '' });
+  const router = useRouter();
 
   const handleChange = (field) => (e) => {
     setValues({ ...values, [field]: e.target.value });
@@ -14,6 +16,7 @@ export default function RegisterPage() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    router.push('/account');
   };
 
   return (


### PR DESCRIPTION
## Summary
- redirect registration page to new account details form
- add account details form with certificate upload

## Testing
- `npm --prefix insight run lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_6848d75062f083218b8c36c9e5e6e633