### PR TITLE
Improve authentication flow and styling

### DIFF
--- a/insight/app/account/page.js
+++ b/insight/app/account/page.js
@@ -1,23 +1,77 @@
 'use client';
 
 import { useState } from 'react';
-import { Avatar, Box, Button, Container, Typography } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { Box, Button, Container, TextField, Typography } from '@mui/material';
 import Navbar from '../components/navbar';
 
 export default function AccountPage() {
-  const [user] = useState({ name: 'John Doe', email: 'john@example.com' });
+  const router = useRouter();
+  const [values, setValues] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    certificate: null,
+  });
+
+  const handleChange = (field) => (e) => {
+    setValues({ ...values, [field]: e.target.value });
+  };
+
+  const handleFileChange = (e) => {
+    setValues({ ...values, certificate: e.target.files[0] });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    router.push('/');
+  };
 
   return (
     <>
       <Navbar />
       <Container maxWidth="sm" sx={{ mt: 8 }}>
-        <Box display="flex" flexDirection="column" alignItems="center">
-          <Avatar sx={{ width: 80, height: 80, mb: 2 }}>{user.name.charAt(0)}</Avatar>
-          <Typography variant="h5">{user.name}</Typography>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            {user.email}
+        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Account Details
           </Typography>
-          <Button variant="contained">Edit</Button>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="First Name"
+            value={values.firstName}
+            onChange={handleChange('firstName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Last Name"
+            value={values.lastName}
+            onChange={handleChange('lastName')}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label="Email Address"
+            type="email"
+            value={values.email}
+            onChange={handleChange('email')}
+          />
+          <Button variant="outlined" component="label" sx={{ mt: 2 }}>
+            Upload Certificate
+            <input hidden type="file" onChange={handleFileChange} />
+          </Button>
+          {values.certificate && (
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              {values.certificate.name}
+            </Typography>
+          )}
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3 }}>
+            Save
+          </Button>
         </Box>
       </Container>
     </>

--- a/insight/app/components/Testimonials.js
+++ b/insight/app/components/Testimonials.js
@@ -20,7 +20,7 @@ export default function TestimonialsSection() {
         <div className="flex flex-col md:flex-row gap-8 justify-center">
           {testimonials.map((t, i) => (
             <div key={i} className="bg-blue-50 rounded-lg p-6 shadow w-full md:w-1/3">
-              <p className="text-blue-700 italic mb-4">"{t.text}"</p>
+              <p className="text-blue-700 italic mb-4">&ldquo;{t.text}&rdquo;</p>
               <div className="font-semibold text-blue-900">{t.name}</div>
               <div className="text-blue-600 text-sm">{t.role}</div>
             </div>

--- a/insight/app/login/page.js
+++ b/insight/app/login/page.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, Container, Link, TextField, Typography } from '@mui/material';
+import { Box, Button, Container, Link, Paper, TextField, Typography } from '@mui/material';
 import NextLink from 'next/link';
 import Navbar from '../components/navbar';
 
@@ -16,8 +16,10 @@ export default function LoginPage() {
   return (
     <>
       <Navbar />
-      <Container maxWidth="sm" sx={{ mt: 8 }}>
-        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+      <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
+        <Container maxWidth="sm">
+          <Paper elevation={3} sx={{ p: 4 }}>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
           <Typography variant="h4" component="h1" gutterBottom>
             Sign in
           </Typography>
@@ -43,13 +45,15 @@ export default function LoginPage() {
             Sign In
           </Button>
           <Typography variant="body2" sx={{ mt: 2 }}>
-            Don't have an account?{' '}
+            {'Don\u2019t have an account? '}
             <Link component={NextLink} href="/register">
               Sign up
             </Link>
           </Typography>
-        </Box>
-      </Container>
+            </Box>
+          </Paper>
+        </Container>
+      </Box>
     </>
   );
 }

--- a/insight/app/register/page.js
+++ b/insight/app/register/page.js
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, Container, Link, TextField, Typography } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { Box, Button, Container, Link, Paper, TextField, Typography } from '@mui/material';
 import NextLink from 'next/link';
 import Navbar from '../components/navbar';
 
 export default function RegisterPage() {
   const [values, setValues] = useState({ firstName: '', lastName: '', email: '', password: '' });
+  const router = useRouter();
 
   const handleChange = (field) => (e) => {
     setValues({ ...values, [field]: e.target.value });
@@ -14,13 +16,16 @@ export default function RegisterPage() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    router.push('/signup/consultant');
   };
 
   return (
     <>
       <Navbar />
-      <Container maxWidth="sm" sx={{ mt: 8 }}>
-        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+      <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
+        <Container maxWidth="sm">
+          <Paper elevation={3} sx={{ p: 4 }}>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
           <Typography variant="h4" component="h1" gutterBottom>
             Sign up
           </Typography>
@@ -67,8 +72,10 @@ export default function RegisterPage() {
               Sign in
             </Link>
           </Typography>
-        </Box>
-      </Container>
+            </Box>
+          </Paper>
+        </Container>
+      </Box>
     </>
   );
 }

--- a/insight/app/signup/consultant/page.js
+++ b/insight/app/signup/consultant/page.js
@@ -1,5 +1,7 @@
 'use client';
 import { useState } from 'react';
+import { Box, Container, Paper } from '@mui/material';
+import { useRouter } from 'next/navigation';
 import Navbar from '../../components/navbar';
 export default function ConsultantProfilePage() {
   const [form, setForm] = useState({
@@ -25,6 +27,7 @@ export default function ConsultantProfilePage() {
   });
   const [errors, setErrors] = useState({});
   const [submitted, setSubmitted] = useState(false);
+  const router = useRouter();
 
   // Handle input change
   function handleChange(e) {
@@ -75,15 +78,16 @@ export default function ConsultantProfilePage() {
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length === 0) {
       setSubmitted(true);
-      // Submit the form data to your backend here
+      router.push('/');
     }
   }
 
   return (
     <>
     <Navbar />
-    <div className="min-h-screen bg-blue-50 py-12 px-4">
-      <div className="max-w-3xl mx-auto bg-white shadow-lg rounded-xl p-8">
+    <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', py: 4 }}>
+      <Container maxWidth="md">
+        <Paper sx={{ p: 4 }}>
         <h1 className="text-3xl font-bold mb-6 text-blue-900">Consultant Profile Registration</h1>
         {submitted ? (
           <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
@@ -407,8 +411,9 @@ export default function ConsultantProfilePage() {
             Submit Profile
           </button>
         </form>
-      </div>
-    </div>
+        </Paper>
+      </Container>
+    </Box>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- restyle login and register pages with Paper and background
- navigate to consultant signup after registering
- fix consultant signup page layout and add redirect to home
- escape quotes in testimonials

## Testing
- `npm --prefix insight run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848d75062f083218b8c36c9e5e6e633