### PR TITLE
Add user-type tabs and streamline consultant signup

### DIFF
--- a/insight/app/login/page.js
+++ b/insight/app/login/page.js
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, Container, Link, Paper, TextField, Typography } from '@mui/material';
+import { Box, Button, Container, Link, Paper, TextField, Typography, Tabs, Tab } from '@mui/material';
 import NextLink from 'next/link';
 import Navbar from '../components/navbar';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [tab, setTab] = useState('customer');
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -19,6 +20,10 @@ export default function LoginPage() {
             <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
         <Container maxWidth="sm">
           <Paper elevation={3} sx={{ p: 4 }}>
+            <Tabs value={tab} onChange={(e, v) => setTab(v)} centered sx={{ mb: 2 }}>
+              <Tab label="Customer" value="customer" />
+              <Tab label="Consultant" value="consultant" />
+            </Tabs>
             <Box component="form" onSubmit={handleSubmit} noValidate>
           <Typography variant="h4" component="h1" gutterBottom>
             Sign in

--- a/insight/app/register/page.js
+++ b/insight/app/register/page.js
@@ -2,11 +2,13 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Box, Button, Container, Link, Paper, TextField, Typography } from '@mui/material';import NextLink from 'next/link';
+import { Box, Button, Container, Link, Paper, TextField, Typography, Tabs, Tab } from '@mui/material';
+import NextLink from 'next/link';
 import Navbar from '../components/navbar';
 
 export default function RegisterPage() {
   const [values, setValues] = useState({ firstName: '', lastName: '', email: '', password: '' });
+  const [tab, setTab] = useState('customer');
   const router = useRouter();
 
   const handleChange = (field) => (e) => {
@@ -15,7 +17,13 @@ export default function RegisterPage() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    router.push('/signup/consultant');
+    if (tab === 'consultant') {
+      const name = encodeURIComponent(`${values.firstName} ${values.lastName}`.trim());
+      const email = encodeURIComponent(values.email);
+      router.push(`/signup/consultant?name=${name}&email=${email}`);
+    } else {
+      router.push('/');
+    }
   };
 
   return (
@@ -24,6 +32,10 @@ export default function RegisterPage() {
      <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
         <Container maxWidth="sm">
           <Paper elevation={3} sx={{ p: 4 }}>
+            <Tabs value={tab} onChange={(e,v)=>setTab(v)} centered sx={{ mb: 2 }}>
+              <Tab label="Customer" value="customer" />
+              <Tab label="Consultant" value="consultant" />
+            </Tabs>
             <Box component="form" onSubmit={handleSubmit} noValidate>
           <Typography variant="h4" component="h1" gutterBottom>
             Sign up

--- a/insight/app/signup/consultant/page.js
+++ b/insight/app/signup/consultant/page.js
@@ -1,12 +1,13 @@
 'use client';
 import { useState } from 'react';
 import Navbar from '../../components/navbar';
-import { Box, Container, Paper } from '@mui/material';
-import { useRouter } from 'next/navigation';
+import { Box, Container, Paper, TextField, Typography } from '@mui/material';
+import { useRouter, useSearchParams } from 'next/navigation';
 export default function ConsultantProfilePage() {
+  const searchParams = useSearchParams();
   const [form, setForm] = useState({
-    fullName: '',
-    email: '',
+    fullName: searchParams.get('name') || '',
+    email: searchParams.get('email') || '',
     phone: '',
     location: '',
     workType: '',
@@ -99,29 +100,22 @@ export default function ConsultantProfilePage() {
         <form onSubmit={handleSubmit} noValidate>
           {/* Personal Info */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-            <div>
-              <label className="block font-semibold mb-1 text-blue-700">Full Name *</label>
-              <input
-                className={`w-full border rounded px-3 py-2 bg-blue-100 ${errors.fullName ? 'border-red-500' : 'border-blue-200'}`}
-                name="fullName"
-                value={form.fullName}
-                onChange={handleChange}
-                required
-              />
-              {errors.fullName && <p className="text-red-600 text-sm">{errors.fullName}</p>}
-            </div>
-            <div>
-              <label className="block font-semibold mb-1 text-blue-700">Email *</label>
-              <input
-                type="email"
-                className={`w-full border rounded px-3 py-2 bg-blue-100 ${errors.email ? 'border-red-500' : 'border-blue-200'}`}
-                name="email"
-                value={form.email}
-                onChange={handleChange}
-                required
-              />
-              {errors.email && <p className="text-red-600 text-sm">{errors.email}</p>}
-            </div>
+            <TextField
+              label="Full Name"
+              margin="normal"
+              fullWidth
+              size="small"
+              value={form.fullName}
+              disabled
+            />
+            <TextField
+              label="Email"
+              margin="normal"
+              fullWidth
+              size="small"
+              value={form.email}
+              disabled
+            />
             <div>
               <label className="block font-semibold mb-1 text-blue-700">Phone Number *</label>
               <input


### PR DESCRIPTION
## Summary
- add user-type tabs on login page
- add customer/consultant tabs on sign-up page
- prefill consultant signup with name and email from query params

## Testing
- `npm run lint` *(fails: Parsing error & react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_6849be20044083218147267a0c5f65e8