### PR TITLE
Add consultant home page

### DIFF
--- a/insight/app/consultant/home/page.js
+++ b/insight/app/consultant/home/page.js
@@ -1,0 +1,40 @@
+'use client';
+
+import Navbar from '../../components/navbar';
+import { Box, Container, Paper, Typography, List, ListItem, ListItemText } from '@mui/material';
+
+export default function ConsultantHomePage() {
+  const requests = [
+    { id: 1, client: 'Acme Corp', details: 'Seeking assessment for return-to-work program.' },
+    { id: 2, client: 'Smith Industries', details: 'Need training session on disability management.' },
+    { id: 3, client: 'Global Tech', details: 'Looking for ongoing quality assurance consulting.' },
+  ];
+
+  return (
+    <>
+      <Navbar />
+      <Box sx={{ bgcolor: 'grey.100', minHeight: '100vh', py: 4 }}>
+        <Container maxWidth="md">
+          <Typography variant="h4" component="h1" gutterBottom color="primary.main">
+            Consultant Dashboard
+          </Typography>
+          <Paper sx={{ p: 4 }}>
+            <Typography variant="h6" gutterBottom>
+              Latest Client Requests
+            </Typography>
+            <List>
+              {requests.map((req) => (
+                <ListItem key={req.id} divider>
+                  <ListItemText
+                    primary={req.client}
+                    secondary={req.details}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Paper>
+        </Container>
+      </Box>
+    </>
+  );
+}

--- a/insight/app/signup/consultant/page.js
+++ b/insight/app/signup/consultant/page.js
@@ -77,10 +77,10 @@ export default function ConsultantProfilePage() {
     e.preventDefault();
     const validationErrors = validate();
     setErrors(validationErrors);
-    if (Object.keys(validationErrors).length === 0) {
-      setSubmitted(true);
-      // Submit the form data to your backend here
-            router.push('/');
+      if (Object.keys(validationErrors).length === 0) {
+        setSubmitted(true);
+        // Submit the form data to your backend here
+        router.push('/consultant/home');
 
     }
   }


### PR DESCRIPTION
## Summary
- create `/consultant/home` dashboard page for consultants
- redirect consultant signup to new dashboard after successful submission

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c3d9773c8321970c80e943a78be8